### PR TITLE
add methods to remove items from the diff

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,3 +27,6 @@ jobs:
       - name: Run cargo clippy
         working-directory: src/
         run: cargo clippy --all-targets --all-features -- -Dwarnings
+
+      - name: Run cargo test
+        run: cargo test --all-features

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -569,4 +569,24 @@ mod tests {
 
         assert!(diff.is_internally_consistent());
     }
+
+    #[test]
+    fn test_remove_from_diff() {
+        let mut diff = GraphDiff::<usize, NodeUpdate>::new();
+
+        diff.get_or_create_mut_node_update(&0).label = Some("test".to_string());
+        diff.get_or_create_mut_node_update(&0).size = Some(10.0);
+        diff.delete_node(3);
+        diff.add_edge(&0, &1, 1.0).unwrap();
+        diff.delete_edge(&0, &2);
+
+        diff.remove_updated_node(&0);
+        assert!(diff.nodes.new_or_updated.is_empty());
+        diff.remove_deleted_node(&3);
+        assert!(!diff.nodes.deleted.contains(&3));
+        diff.remove_updated_edge(&0, &1);
+        assert!(diff.edges.new_or_updated.is_empty());
+        diff.remove_deleted_edge(&0, &2);
+        assert!(!diff.edges.deleted.contains_key(&0));
+    }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -241,6 +241,47 @@ impl<Id: Hash + Eq + Copy, T: Default + AddAssign, W: Copy + PartialEq> GraphDif
         self.edges.deleted.clear();
     }
 
+    /// Remove a new or updated node from the diff.
+    /// Returns the update if there was one.
+    pub fn remove_updated_node(&mut self, id: &Id) -> Option<T> {
+        self.nodes.new_or_updated.remove(id)
+    }
+
+    /// Remove a node marked for deletion from the diff.
+    /// Returns `true` if the node was marked for deletion.
+    pub fn remove_deleted_node(&mut self, id: &Id) -> bool {
+        self.nodes.deleted.remove(id)
+    }
+
+    /// Remove a new updated edge from the diff.
+    /// Returns the updated weight if there was one.
+    pub fn remove_updated_edge(&mut self, from: &Id, to: &Id) -> Option<W> {
+        let removed = self
+            .edges
+            .new_or_updated
+            .get_mut(from)
+            .and_then(|edges| edges.remove(to));
+        if removed.is_some() {
+            self.edges.new_or_updated.retain(|_, e| !e.is_empty());
+        }
+        removed
+    }
+
+    /// Remove an edge marked for deletion from the diff.
+    /// Returns `true` if the edge was marked for deletion.
+    pub fn remove_deleted_edge(&mut self, from: &Id, to: &Id) -> bool {
+        let deleted = self
+            .edges
+            .deleted
+            .get_mut(from)
+            .map(|edges| edges.remove(to))
+            .unwrap_or(false);
+        if deleted {
+            self.edges.deleted.retain(|_, e| !e.is_empty());
+        }
+        deleted
+    }
+
     #[cfg(test)]
     fn is_internally_consistent(&self) -> bool {
         for (from, to_weight) in self.edges.new_or_updated.iter() {


### PR DESCRIPTION
Adds methods to allow removing specific elements from the diff (i.e. remove them from `new_or_updated` rather than call `delete`).