### PR TITLE
add nx interface

### DIFF
--- a/python/drisk_api/interfaces/nx.py
+++ b/python/drisk_api/interfaces/nx.py
@@ -1,0 +1,33 @@
+"""Export graphs to networkx."""
+try:
+    import networkx as nx
+except ImportError as e:
+    raise ImportError(
+        f"NetworkX is required for this module. Please install it.\n{e}"
+    )
+
+import json
+from io import BytesIO
+from zipfile import ZipFile
+
+import requests
+
+from drisk_api.graph_client import EdgeException, GraphClient
+
+
+def graph_to_networkx(graph: GraphClient) -> nx.DiGraph:
+    """Convert a graph to a NetworkX graph."""
+    r = requests.get(
+        f"{graph.url}/{graph.graph_id}/export-node-link",
+        headers={"Authorization": graph.auth_token},
+    )
+    if r.status_code >= 300:
+        raise EdgeException(r.status_code, r.text)
+    zipped = ZipFile(BytesIO(r.content))
+    unzipped = zipped.read(f"{graph.graph_id}_node_link.json").decode("utf-8")
+    data = json.loads(unzipped)
+
+    # apply default properties to nodes
+    data["nodes"] = [{**graph.defaults, **n} for n in data["nodes"]]
+
+    return nx.node_link_graph(data, multigraph=False, directed=True)


### PR DESCRIPTION
Adds a `networkx` interface which allows exporting an entire graph to a `networkx` graph. This an external interface so does not add `networkx` as a dependency of `drisk_api`.