### PR TITLE
add getter methods to pygraphdiff

### DIFF
--- a/python/drisk_api/graph_client.py
+++ b/python/drisk_api/graph_client.py
@@ -242,7 +242,7 @@ class GraphClient:
         """
         return self._get_node_request(node_id, "predecessors", weights=weights)
 
-    def get_edges(self, nodes: Iterable[UUID]) -> dict:
+    def get_edges(self, nodes: Iterable[UUID]) -> Dict:
         """
         Get all edges between the given nodes.
 
@@ -251,7 +251,7 @@ class GraphClient:
 
         Returns
         -------
-            dict: Nested dictionary representing edges between nodes.
+            Dict: Nested dictionary representing edges between nodes.
                 Format: {from_node_id: {to_node_id: weight}}.
                 Returns a dictionary for each given node even if it has no edges.
 
@@ -390,7 +390,7 @@ class GraphClient:
         node_id: UUID,
         nbr_type: Optional[str] = None,
         weights: bool = False,
-    ) -> Union[dict, List[UUID], List[Tuple[UUID, float]]]:
+    ) -> Union[Dict, List[UUID], List[Tuple[UUID, float]]]:
         """
         Retrieve information about a node from the server.
 
@@ -402,7 +402,8 @@ class GraphClient:
 
         Returns
         -------
-            dict: JSON response containing information about the node.
+            JSON response containing information about the node, its neighbors or
+            its neighbors and edge weights.
 
         Raises
         ------
@@ -659,13 +660,13 @@ class Node:
         self.graph.update_node(self.id, **self._properties)
 
     @property
-    def properties(self) -> dict:
+    def properties(self) -> Dict:
         """
         Get the properties of the node.
 
         Returns
         -------
-            dict: The properties of the node.
+            Dict: The properties of the node.
 
         """
         return self._properties

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -10,9 +10,9 @@ use std::{fmt::Debug, hash::Hash, ops::AddAssign};
 ///
 /// `GraphDiff` requires two generic types:
 /// * `Id` is the type used to index nodes in the graph. It requires standard trait bounds for
-/// index types.
+///   index types.
 /// * `T` is the type used to represent node property updates. It requires `Default` used
-/// when adding a new node to the diff and `AddAssign` to combine updates.
+///   when adding a new node to the diff and `AddAssign` to combine updates.
 ///
 /// `GraphDiff`s support composition with `AddAssign`:
 /// ```

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -3,7 +3,7 @@ use crate::{bytes::graph_diff_to_bytes, diff::GraphDiff, node_update::NodeUpdate
 use pyo3::{
     exceptions::PyException,
     prelude::*,
-    types::{PyAny, PyBytes, PyDict},
+    types::{PyAny, PyBytes, PyDict, PyList},
 };
 use uuid::Uuid;
 
@@ -44,6 +44,29 @@ impl<'s> FromPyObject<'s> for PyNodeUpdate {
     }
 }
 
+impl ToPyObject for NodeUpdate {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let dict = PyDict::new_bound(py);
+
+        macro_rules! set_item {
+            ($key: expr, $val: expr) => {
+                if let Some(val) = $val {
+                    let _ = dict.set_item($key, val);
+                }
+            };
+        }
+        set_item!("label", &self.label);
+        set_item!("url", &self.url);
+        set_item!("size", self.size);
+        set_item!("red", self.red);
+        set_item!("green", self.green);
+        set_item!("blue", self.blue);
+        set_item!("show_label", self.show_label);
+
+        dict.into()
+    }
+}
+
 impl From<PyNodeUpdate> for NodeUpdate {
     fn from(node_update: PyNodeUpdate) -> Self {
         NodeUpdate {
@@ -79,6 +102,53 @@ impl PyGraphDiff {
         PyGraphDiff(GraphDiff::<_, _, f32>::new())
     }
 
+    fn new_or_updated_nodes<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyDict>> {
+        let dict = PyDict::new_bound(py);
+        for (id, node) in self.0.new_or_updated_nodes() {
+            dict.set_item(id.to_string(), node.to_object(py))?;
+        }
+        PyResult::Ok(dict)
+    }
+
+    fn deleted_nodes<'a>(&self, py: Python<'a>) -> Bound<'a, PyList> {
+        let ids = self
+            .0
+            .deleted_nodes()
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>();
+        let list = PyList::new_bound(py, ids);
+        list
+    }
+
+    fn new_or_updated_edges<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyDict>> {
+        let dict = PyDict::new_bound(py);
+        for (from, tos) in self.0.new_or_updated_edges() {
+            if tos.is_empty() {
+                continue;
+            }
+            let tos_dict = PyDict::new_bound(py);
+            for (to, weight) in tos {
+                tos_dict.set_item(to.to_string(), weight)?;
+            }
+            dict.set_item(from.to_string(), tos_dict)?;
+        }
+        PyResult::Ok(dict)
+    }
+
+    fn deleted_edges<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyDict>> {
+        let dict = PyDict::new_bound(py);
+        for (from, tos) in self.0.deleted_edges() {
+            if tos.is_empty() {
+                continue;
+            }
+            let tos_list =
+                PyList::new_bound(py, tos.iter().map(|to| to.to_string()).collect::<Vec<_>>());
+            dict.set_item(from.to_string(), tos_list)?;
+        }
+        PyResult::Ok(dict)
+    }
+
     fn num_nodes(&self) -> usize {
         self.0.nodes.get_new_or_updated().len() + self.0.nodes.get_deleted().len()
     }
@@ -103,14 +173,21 @@ impl PyGraphDiff {
         self.0.delete_edge(&from.0, &to.0);
     }
 
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+
     fn to_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
         let bytes = graph_diff_to_bytes(&self.0)
             .map_err(|_| PyException::new_err("Failed to serialize graph diff."))?;
         Ok(PyBytes::new_bound(py, &bytes))
     }
 
-    fn clear(&mut self) {
-        self.0.clear();
+    #[staticmethod]
+    fn from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyGraphDiff> {
+        let graph_diff = crate::bytes::bytes_to_graph_diff(bytes.as_bytes())
+            .map_err(|_| PyException::new_err("Failed to deserialize graph diff."))?;
+        Ok(PyGraphDiff(graph_diff))
     }
 }
 


### PR DESCRIPTION
* Adds methods to `PyGraphDiff` to allow Python to get data inside the diff. These can return the new/deleted nodes/edges as dicts or lists. Note these are copies of the underlying data so these methods cannot be used to mutate the diff.
* Adds a `from_bytes` method to `PyGraphDiff` which can create a diff from raw bytes.
* Changes the return type of `get_successors` to match the hint when weights are returned which is a list of tuples rather than a tuple of lists.