### PR TITLE
BUGFIX: fixing legacy use cases of get_successors

### DIFF
--- a/python/drisk_api/graph_client.py
+++ b/python/drisk_api/graph_client.py
@@ -320,7 +320,7 @@ class GraphClient:
         x_node, y_node, *filters = [
             uuid
             for uuid, _ in sorted(
-                zip(*self.get_successors(view_node, weights=True)),
+                self.get_successors(view_node, weights=True),
                 key=lambda x: x[1],
             )
         ]
@@ -342,7 +342,7 @@ class GraphClient:
         x_node, y_node, *_ = [
             uuid
             for uuid, _ in sorted(
-                zip(*self.get_successors(view_node, weights=True)),
+                self.get_successors(view_node, weights=True),
                 key=lambda x: x[1],
             )
         ]


### PR DESCRIPTION
The API returns a list of tuples and not a tuple of lists hence the bugfix