### PR TITLE
allow no skip-if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["lib", "cdylib"]
 
 [features]
 extension-module = ["dep:pyo3"]
+no-skip-if = []
 
 [dependencies]
 bincode = { version = "1.3.3" }

--- a/src/node_update.rs
+++ b/src/node_update.rs
@@ -4,19 +4,40 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeUpdate {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub label: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub size: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub red: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub green: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub blue: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        not(feature = "no-skip-if"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub show_label: Option<bool>,
 }
 


### PR DESCRIPTION
Add a feature to optionally remove the `serde(skip_serializing_if` attribute. Removing this enables `bincode` serialisation of `NodeUpdate` and hence `GraphDiff`.